### PR TITLE
Added categories to UrlInfo

### DIFF
--- a/lib/alexa/api/url_info.rb
+++ b/lib/alexa/api/url_info.rb
@@ -3,7 +3,7 @@ require "alexa/api/base"
 module Alexa
   module API
     class UrlInfo < Base
-      DEFAULT_RESPONSE_GROUP = ["adult_content", "contact_info", "keywords", "language", "links_in_count", "owned_domains", "rank", "rank_by_city", "rank_by_country", "related_links", "site_data", "speed", "usage_stats"]
+      DEFAULT_RESPONSE_GROUP = ["adult_content", "contact_info", "keywords", "language", "links_in_count", "owned_domains", "rank", "rank_by_city", "rank_by_country", "related_links", "site_data", "speed", "usage_stats", "categories"]
 
       def fetch(arguments = {})
         raise ArgumentError, "You must specify url" unless arguments.has_key?(:url)
@@ -83,6 +83,10 @@ module Alexa
 
       def related_links
         @related_links ||= safe_retrieve(parsed_body, "UrlInfoResponse", "Response", "UrlInfoResult", "Alexa", "Related", "RelatedLinks", "RelatedLink")
+      end
+      
+      def categories
+        @categories ||= safe_retrieve(parsed_body, "UrlInfoResponse", "Response", "UrlInfoResult", "Alexa", "Related", "Categories", "CategoryData")
       end
 
       def status_code

--- a/test/api/url_info_test.rb
+++ b/test/api/url_info_test.rb
@@ -108,6 +108,10 @@ describe Alexa::API::UrlInfo do
     it "returns usage statistics" do
       assert_equal 4, @url_info.usage_statistics.size
     end
+    
+    it "returns categories" do
+      assert_equal 2, @url_info.categories.size
+    end
 
     it "has success status code" do
       assert_equal "Success", @url_info.status_code

--- a/test/fixtures/url_info/github_full.txt
+++ b/test/fixtures/url_info/github_full.txt
@@ -87,6 +87,16 @@ Date: Wed, 12 Oct 2011 16:41:16 GMT
         <aws:Title>Agile Web Development</aws:Title>
       </aws:RelatedLink>
     </aws:RelatedLinks>
+	<aws:Categories>
+	  <aws:CategoryData>
+	    <aws:Title>Open Source/Project Hosting</aws:Title>
+	    <aws:AbsolutePath>Top/Computers/Open_Source/Project_Hosting</aws:AbsolutePath>
+	  </aws:CategoryData>
+	  <aws:CategoryData>
+	    <aws:Title>Tools/Git</aws:Title>
+	    <aws:AbsolutePath>Top/Computers/Software/Configuration_Management/Tools/Git</aws:AbsolutePath>
+	  </aws:CategoryData>
+	</aws:Categories>
   </aws:Related>
   <aws:TrafficData>
     <aws:DataUrl type="canonical">github.com</aws:DataUrl>


### PR DESCRIPTION
Alexa's UrlInfo API call includes a response group called "Categories" which lists up to 3 DMOZ categories for the specified URL. These categories come back in the aws:Request group (similar to the RelatedLinks).

I have modified url_info.rb (along with the matching tests and fixtures) to include these categories by default, as well as to include a method that returns them.
