### PR TITLE
Switch from raw Net::HTTP to Faraday

### DIFF
--- a/alexa.gemspec
+++ b/alexa.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Alexa::VERSION
 
   gem.add_dependency "multi_xml", ">= 0.5.0"
+  gem.add_dependency "faraday", "~> 0.8.7"
 
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "webmock"

--- a/lib/alexa/connection.rb
+++ b/lib/alexa/connection.rb
@@ -2,7 +2,7 @@ require "cgi"
 require "base64"
 require "openssl"
 require "digest/sha1"
-require "net/http"
+require "faraday"
 require "time"
 
 module Alexa
@@ -25,7 +25,7 @@ module Alexa
     end
 
     def handle_response(response)
-      case response.code.to_i
+      case response.status.to_i
       when 200...300
         response
       when 300...600
@@ -42,7 +42,7 @@ module Alexa
     end
 
     def request
-      Net::HTTP.get_response(uri)
+      Faraday.get(uri)
     end
 
     def timestamp


### PR DESCRIPTION
I've modified the gem to use Faraday, as opposed to raw Net::HTTP. I know this adds a potentially unwanted dependency, but Faraday is very common these days. By default, it uses Net::HTTP so the performance should be identical.

The reason for this is because now if someone wanted to increase the performance of the gem, they could swap out the HTTP backend to be Typhoeus or similar, using something like this:

```
require 'alexa'
require 'faraday'
require 'typhoeus/adapters/faraday'

Faraday.default_adapter = :typhoeus

client = Alexa::Client.new(access_key_id: "key", secret_access_key: "secret")
url_info = client.url_info(url: "site.com")
```

All tests are passing for me but I welcome any comments
