### PR TITLE
Make faraday dependency less restrictive.

### DIFF
--- a/alexa.gemspec
+++ b/alexa.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Alexa::VERSION
 
   gem.add_dependency "multi_xml", ">= 0.5.0"
-  gem.add_dependency "faraday", "~> 0.8.7"
+  gem.add_dependency "faraday", "~> 0.8"
 
   gem.add_development_dependency "minitest", ">= 5.0.0"
   gem.add_development_dependency "mocha"


### PR DESCRIPTION
Assume that Faraday uses Semantic versioning for the most part. Restrictive Faraday dependencies cause lots and lots of gem dependency conflicts because so many different gems use Faraday.
