### PR TITLE
Fix invalid signature when spaces are present

### DIFF
--- a/lib/alexa/connection.rb
+++ b/lib/alexa/connection.rb
@@ -72,7 +72,7 @@ module Alexa
     end
 
     def query
-      default_params.merge(params).map { |key, value| "#{key}=#{CGI::escape(value.to_s)}" }.sort.join("&")
+      default_params.merge(params).map { |key, value| "#{key}=#{URI.escape(value.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}" }.sort.join("&")
     end
   end
 end


### PR DESCRIPTION
Correctly encode query params: signature version 2 should encode the
space character as "%20" and not "+".

See: http://docs.aws.amazon.com/AlexaWebInfoService/latest/CalculatingSignatures.html
